### PR TITLE
Fix catalyst builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -180,7 +180,11 @@ if [ "$MAC_CATALYST" = true ]; then
     plist_add_architecture $LIB_COUNT "arm64"
 
     cp -RP out/catalyst-x64/WebRTC.framework "${XCFRAMEWORK_DIR}/${CATALYST_LIB_IDENTIFIER}"
-    lipo -create -output "${XCFRAMEWORK_DIR}/${CATALYST_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" out/catalyst-x64/WebRTC.framework/WebRTC out/catalyst-arm64/WebRTC.framework/WebRTC
+	# the next line is just to be sure (this could not be needed)
+    rm "${XCFRAMEWORK_DIR}/${CATALYST_LIB_IDENTIFIER}/WebRTC.framework/Versions/A/WebRTC"
+    lipo -create -output "${XCFRAMEWORK_DIR}/${CATALYST_LIB_IDENTIFIER}/WebRTC.framework/Versions/A/WebRTC" out/catalyst-x64/WebRTC.framework/WebRTC out/catalyst-arm64/WebRTC.framework/WebRTC
+    # symlink the file to make xcode happy (error: codesign failed: bundle format is ambiguous (could be app or framework))
+    ln -s "Versions/Current/WebRTC" "${XCFRAMEWORK_DIR}/${CATALYST_LIB_IDENTIFIER}/WebRTC.framework/WebRTC"
     LIB_COUNT=$((LIB_COUNT+1))
 fi
 


### PR DESCRIPTION
Using WebRTC with catalyst results in this error:
"codesign failed: bundle format is ambiguous (could be app or framework)"
It turns out this is because of a missing symlink in "ios-x86_64_arm64-maccatalyst/WebRTC.framework": WebRTC should be symlinked to point to "Versions/Current/WebRTC".

The binary at "Versions/Current/WebRTC" on the other hand is the wrong one (no multi arch) and should be removed in favor of "ios-x86_64_arm64-maccatalyst/WebRTC.framework/WebRTC"

This PR executes this whole shell game.