### PR TITLE
Codesign simulator framework

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -151,6 +151,10 @@ if [[ "$IOS" = true ]]; then
     lipo -create -output  "${XCFRAMEWORK_DIR}/${IOS_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_IOS_FLAGS}
     lipo -create -output "${XCFRAMEWORK_DIR}/${IOS_SIM_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_IOS_SIM_FLAGS}
 
+    # codesign simulator framework for local development.
+    # This makes it possible for Swift Packages to run Unit Tests and show SwiftUI Previews.
+    xcrun codesign -s - "${XCFRAMEWORK_DIR}/${IOS_SIM_LIB_IDENTIFIER}/WebRTC.framework/WebRTC"
+
     LIB_COUNT=$((LIB_COUNT+2))
 fi
 


### PR DESCRIPTION
In my team we have the bulk of our application developed in a standalone Swift Package. 
As it stands, with WebRTC as a dependency, we cannot:

1. Run Swift UI previews.
2. Run unit tests on iOS simulator.

The main problem is that, the simulator framework is not signed, thus it cannot be used purely from a Swift Package.
This PR proposes to sign the simulator framework to run locally.

Attempt to fix #56 #59 