### PR TITLE
Fix release workflow build failures

### DIFF
--- a/.github/workflows/webrtc-build.yml
+++ b/.github/workflows/webrtc-build.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+      # WebRTC milestone branches ship with frozen Chromium buildtools that
+      # only support the Xcode/SDK version current at the time of the branch
+      # cut. Newer Xcode versions introduce SDK framework splits (e.g.
+      # DarwinFoundation, UIUtilities) that break the build. Pin to the
+      # version expected by the buildtools (see build/mac_toolchain.py in
+      # the WebRTC source for each milestone).
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app
       - name: Building WebRTC framework
         run: |
           sh clean.sh
@@ -45,4 +53,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: WebRTC.xcframework
-          path: src/out/WebRTC.xcframework
+          path: src/out/WebRTC-*.xcframework.zip

--- a/.github/workflows/webrtc-release.yml
+++ b/.github/workflows/webrtc-release.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+      # WebRTC milestone branches ship with frozen Chromium buildtools that
+      # only support the Xcode/SDK version current at the time of the branch
+      # cut. Newer Xcode versions introduce SDK framework splits (e.g.
+      # DarwinFoundation, UIUtilities) that break the build. Pin to the
+      # version expected by the buildtools (see build/mac_toolchain.py in
+      # the WebRTC source for each milestone).
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/webrtc-release.yml
+++ b/.github/workflows/webrtc-release.yml
@@ -3,7 +3,7 @@ run-name: WebRTC Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 12 * * 3'
+    - cron: '0 12 * * *'
 jobs:
   Build-Script:
     runs-on: macos-latest
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - name: Running WebRTC weekly release checks
+      - name: Running WebRTC release checks
         run: |
           sh clean.sh
           pip install requests python-telegram-bot

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,7 +39,7 @@ def getStableMilestone():
 
 def getNextRelease():
     # Get current version
-    releases = requests.get("https://api.github.com/repos/stasel/WebRTC/releases", headers={'Authorization': f"token {GITHUB_TOKEN}"}).json()
+    releases = requests.get(f"https://api.github.com/repos/{GITHUB_REPO}/releases", headers={'Authorization': f"token {GITHUB_TOKEN}"}).json()
     print(releases)
     latestReleaseVersion = int(releases[0]["tag_name"].split(".")[0])
     latestReleaseDate = datetime.fromisoformat(releases[0]["published_at"].replace("Z", ""))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import telegram
 
 GITHUB_TOKEN=os.environ.get("GITHUB_TOKEN")
+GITHUB_REPO=os.environ.get("GITHUB_REPOSITORY", "stasel/WebRTC")
 TELEGRAM_TOKEN=os.environ.get("TELEGRAM_TOKEN")
 TELEGRAM_CHAT_ID=os.environ.get("TELEGRAM_CHAT_ID")
 
@@ -22,6 +23,20 @@ class BuildMetadata:
     commit: str
     branch: str
 
+def getStableMilestone():
+    """Find the current stable milestone from the Chromium Dashboard."""
+    try:
+        response = requests.get("https://chromiumdash.appspot.com/fetch_milestones")
+        response.raise_for_status()
+        milestones = response.json()
+        stable = [m for m in milestones if m.get("schedule_phase") == "stable"]
+        if stable:
+            return int(max(stable, key=lambda m: m["milestone"])["milestone"])
+        print("Warning: no milestone with schedule_phase 'stable' found")
+    except (requests.RequestException, KeyError, ValueError, TypeError) as e:
+        print(f"Warning: failed to fetch stable milestone: {e}")
+    return None
+
 def getNextRelease():
     # Get current version
     releases = requests.get("https://api.github.com/repos/stasel/WebRTC/releases", headers={'Authorization': f"token {GITHUB_TOKEN}"}).json()
@@ -30,8 +45,16 @@ def getNextRelease():
     latestReleaseDate = datetime.fromisoformat(releases[0]["published_at"].replace("Z", ""))
     print(f"Latest release: version {latestReleaseVersion}, date: {latestReleaseDate}")
 
-    # Get next version
-    nextReleaseVersion = latestReleaseVersion + 1
+    # Get the current stable milestone
+    stableMilestone = getStableMilestone()
+    if not stableMilestone:
+        print("❌ Could not determine current stable milestone")
+        os._exit(os.EX_SOFTWARE)
+
+    nextReleaseVersion = max(latestReleaseVersion + 1, stableMilestone)
+    if nextReleaseVersion > latestReleaseVersion + 1:
+        print(f"Current stable milestone is M{stableMilestone}, skipping ahead from M{latestReleaseVersion + 1}")
+
     milestones = requests.get(f"https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone={nextReleaseVersion}").json()
     nextReleaseDate = datetime.fromisoformat(milestones["mstones"][0]["stable_date"])
     print(f"Next release:   version {nextReleaseVersion}, date: {nextReleaseDate}")
@@ -72,7 +95,7 @@ def createReleaseDraft(release, buildMetadata):
         'body': body
     }
     headers = {'accept': 'application/vnd.github.v3+json', 'Authorization': f'token {GITHUB_TOKEN}'}
-    return requests.post("https://api.github.com/repos/stasel/WebRTC/releases", json = fields, headers = headers).json()
+    return requests.post(f"https://api.github.com/repos/{GITHUB_REPO}/releases", json = fields, headers = headers).json()
 
 def uploadReleaseAsset(url, assetLocalPath, assetName):
     url = url.replace(u'{?name,label}','')
@@ -94,7 +117,7 @@ def createPullRequest(release, head):
         'base': 'latest',
         'body': 'Created by an automated sotfware 🤖'
     }
-    response = requests.post("https://api.github.com/repos/stasel/WebRTC/pulls", json = body, headers = headers)
+    response = requests.post(f"https://api.github.com/repos/{GITHUB_REPO}/pulls", json = body, headers = headers)
     success = response.status_code == requests.codes.created
     if not success:
         print(response)
@@ -162,7 +185,7 @@ if __name__ == "__main__":
     cartageFile = open("WebRTC.json", 'r')
 
     cartageJSON = json.loads(cartageFile.read())
-    cartageJSON[f'{nextRelease.version}.0.0'] = f'https://github.com/stasel/WebRTC/releases/download/{nextRelease.version}.0.0/WebRTC-M{nextRelease.version}.xcframework.zip'
+    cartageJSON[f'{nextRelease.version}.0.0'] = f'https://github.com/{GITHUB_REPO}/releases/download/{nextRelease.version}.0.0/WebRTC-M{nextRelease.version}.xcframework.zip'
     cartageFile.close()
     cartageJSONWrite = open("WebRTC.json", 'w')
     cartageJSONWrite.write(json.dumps(cartageJSON, indent=4, sort_keys=True))
@@ -186,7 +209,7 @@ if __name__ == "__main__":
     if TELEGRAM_TOKEN and TELEGRAM_CHAT_ID:
         print("➡️ Sending Telegram notification...")
         bot = telegram.Bot(token=TELEGRAM_TOKEN)
-        message = f"New WebRTC Release M{nextRelease.version} is now available.\nCheck the PR here: https://github.com/stasel/WebRTC/pulls"
+        message = f"New WebRTC Release M{nextRelease.version} is now available.\nCheck the PR here: https://github.com/{GITHUB_REPO}/pulls"
         bot.send_message(chat_id=TELEGRAM_CHAT_ID, text=message)
 
     print(f"✅ Done")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -178,10 +178,10 @@ if __name__ == "__main__":
 
     # Change code
     print("➡️ Applying code changes...")
-    os.system(f"sed -i '' -E 's/[0-9]+.0.0\/WebRTC-M[0-9]+/{nextRelease.version}.0.0\/WebRTC-M{nextRelease.version}/g' Package.swift WebRTC-lib.podspec")
+    os.system(f"sed -i '' -E 's/[0-9]+\.[0-9]+\.[0-9]+\/WebRTC-M[0-9]+/{nextRelease.version}.0.0\/WebRTC-M{nextRelease.version}/g' Package.swift WebRTC-lib.podspec")
     os.system(f"sed -i '' -E 's/checksum: \"[0-9a-f]+\"/checksum: \"{buildMetadata.checksum}\"/g' Package.swift WebRTC-lib.podspec ")
-    os.system(f"sed -i '' -E 's/.upToNextMajor\\(\"[0-9]+.0.0/.upToNextMajor\\(\"{nextRelease.version}.0.0/g' README.md")
-    os.system(f"sed -i '' -E 's/spec.version      = \"[0-9]+.0.0\"/spec.version      = \"{nextRelease.version}.0.0\"/g' WebRTC-lib.podspec")
+    os.system(f"sed -i '' -E 's/.upToNextMajor\\(\"[0-9]+\.[0-9]+\.[0-9]+/.upToNextMajor\\(\"{nextRelease.version}.0.0/g' README.md")
+    os.system(f"sed -i '' -E 's/spec.version      = \"[0-9]+\.[0-9]+\.[0-9]+\"/spec.version      = \"{nextRelease.version}.0.0\"/g' WebRTC-lib.podspec")
     cartageFile = open("WebRTC.json", 'r')
 
     cartageJSON = json.loads(cartageFile.read())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -115,7 +115,7 @@ def createPullRequest(release, head):
         'title': f'Release M{release.version}',
         'head': head,
         'base': 'latest',
-        'body': 'Created by an automated sotfware 🤖'
+        'body': f'Updated files for release M{release.version}.'
     }
     response = requests.post(f"https://api.github.com/repos/{GITHUB_REPO}/pulls", json = body, headers = headers)
     success = response.status_code == requests.codes.created


### PR DESCRIPTION
The weekly release workflow has been failing since late October 2025. There were two independent problems:

**1. Release script stuck on outdated milestones**

`getNextRelease()` always targets `latestRelease + 1`, so after M141 it kept trying to build M142 every week. M142's buildtools were incompatible with the CI runner, so it failed repeatedly while Chromium stable advanced to M144.

The script now queries the Chromium Dashboard `fetch_milestones` API for the current stable milestone and skips ahead to it. If the API call fails, the script exits with an error.

**2. Xcode SDK incompatibility**

WebRTC milestone branches ship with frozen Chromium buildtools that only support the Xcode/SDK version current at the time of the branch cut. As GitHub Actions runner images update, newer Xcode versions introduce SDK framework splits (e.g. `DarwinFoundation`, `UIUtilities`) that break the build.

Both workflows now pin Xcode 16.1 (the version expected by current buildtools — see `build/mac_toolchain.py` in the WebRTC source). This needs to be updated when future milestones require a newer Xcode. The manual build workflow also uploads the build output as a zip to preserve macOS framework symlinks.

**Other minor changes:**

- Use `GITHUB_REPOSITORY` env var for all GitHub API calls instead of hardcoding `stasel/WebRTC`. This makes the script work when run from forks.
- Replaced automated PR body, which contained a typo and a grammatical error, with a descriptive message.
- Changed schedule from weekly to daily. The script exits early when no new release is available.
- Fixed version regex in release script sed commands to match any `X.Y.Z` version instead of only `X.0.0`. Patch releases (e.g. `144.0.1`) would break the URL update in `Package.swift`.

**Testing**

The workflow ran successfully and produced [releases](https://github.com/DePasqualeOrg/WebRTC/releases) of the latest versions on [DePasqualeOrg/WebRTC](https://github.com/DePasqualeOrg/WebRTC). The x.0.1 patch versions have been patched for the missing header issue mentioned below, so they work on iOS and macOS.

**Note:** Milestones M141–M144 have a separate issue where framework headers aren't copied into the bundle ([webrtc:450130875](https://issues.webrtc.org/u/1/issues/450130875)), which causes build failures in Xcode. [CL 424441](https://webrtc-review.googlesource.com/c/src/+/424441) fixed this for iOS but not for macOS — the macOS framework is still missing headers as of M145. The upstream fix adds `create_bracket_include_headers` as a dependency for `mac_framework_bundle` but doesn't copy the generated headers into the bundle's `Versions/A/Headers/` directory.