### PR TITLE
Add tvOS support to WebRTC XCFramework builds

### DIFF
--- a/.github/workflows/webrtc-build.yml
+++ b/.github/workflows/webrtc-build.yml
@@ -27,6 +27,11 @@ on:
         required: true
         default: true
         type: boolean
+      tvos:
+        description: "Build tvOS libraries"
+        required: true
+        default: true
+        type: boolean
 jobs:
   Build-Script:
     runs-on: macos-latest
@@ -53,6 +58,7 @@ jobs:
           IOS: ${{ inputs.ios }}
           MACOS: ${{ inputs.macos }}
           MAC_CATALYST: ${{ inputs.maccatalyst }}
+          TVOS: ${{ inputs.tvos }}
       - name: Upload framework
         uses: actions/upload-artifact@v6
         with:

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "WebRTC",
-    platforms: [.iOS(.v10), .macOS(.v10_11)],
+    platforms: [.iOS(.v10), .macOS(.v10_11), .tvOS(.v12)],
     products: [
         .library(
             name: "WebRTC",

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# WebRTC Binaries for iOS and macOS
+# WebRTC Binaries for iOS, tvOS, and macOS
 [![Latest version](https://img.shields.io/github/v/release/stasel/webrtc)](https://github.com/stasel/WebRTC/releases)
 [![Release Date](https://img.shields.io/github/release-date/stasel/webrtc)](https://github.com/stasel/WebRTC/releases)
 [![Total Downloads](https://img.shields.io/github/downloads/stasel/webrtc/total)](https://github.com/stasel/WebRTC/releases)
 [![Cocoapods](https://img.shields.io/cocoapods/v/WebRTC-lib)](https://cocoapods.org/pods/WebRTC-lib)
 
 
-This repository contains a community-driven distribution of WebRTC framework binaries for iOS and macOS.
+This repository contains a community-driven distribution of WebRTC framework binaries for iOS, tvOS, and macOS.
 
 Since version M80, Google has [deprecated](https://groups.google.com/g/discuss-webrtc/c/Ozvbd0p7Q1Y/m/M4WN2cRKCwAJ?pli=1) their mobile binary libraries distributions (Was officially using the [GoogleWebRTC pod](https://cocoapods.org/pods/GoogleWebRTC)). To get the most up to date WebRTC library, you can compile it on your own, or you can use precompiled binaries from here or other sources.
 
@@ -16,12 +16,13 @@ The binary releases correspond with official Chromium releases and branches as s
 * All binaries in this repository are compiled from the official WebRTC [source code](https://webrtc.googlesource.com/src/) .
 * No modifications are made to the source code or the output binaries.
 * The build process is open source using GitHub actions.
-* Dynamic framework (xcframework format) which contains multiple binaries for macOS and iOS.
+* Dynamic framework (xcframework format) which contains multiple binaries for iOS, tvOS, and macOS.
 * Since [Xcode 14](https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes), bitcode is deprecated. Version M103 and above does not include bitcode.
 * Added support for extra encodings: VP9, H264, H265 (HEVC)
 
 ## 📢 Requirements
 * iOS 12+
+* tvOS 12+
 * macOS 10.11+
 * macOS Catalyst 11.0+
 
@@ -30,6 +31,8 @@ The binary releases correspond with official Chromium releases and branches as s
 |---------------------|--------|---------|
 | **iOS (device)**    |   ✅   |   N/A   |
 | **iOS (simulator)** |   ✅   |    ✅   |
+| **tvOS (device)**   |   ✅   |   N/A   |
+| **tvOS (simulator)**|   ✅   |    ✅   |
 | **macOS**           |   ✅   |    ✅   |
 | **macOS Catalyst**  |   ✅   |    ✅   | 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The binary releases correspond with official Chromium releases and branches as s
 | **iOS (device)**    |   ✅   |   N/A   |
 | **iOS (simulator)** |   ✅   |    ✅   |
 | **tvOS (device)**   |   ✅   |   N/A   |
-| **tvOS (simulator)**|   ✅   |    ✅   |
+| **tvOS (simulator)**|   ✅   |   N/A   |
 | **macOS**           |   ✅   |    ✅   |
 | **macOS Catalyst**  |   ✅   |    ✅   | 
 

--- a/WebRTC-lib.podspec
+++ b/WebRTC-lib.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |spec|
   spec.author       = "Stasel"
   spec.ios.deployment_target = '12.0'
   spec.osx.deployment_target = '10.11'
+  spec.tvos.deployment_target = '12.0'
 
   spec.source       = { :http => "https://github.com/stasel/WebRTC/releases/download/149.0.0/WebRTC-M149.xcframework.zip" }
   spec.vendored_frameworks = "WebRTC.xcframework"

--- a/patches/tvos/BUILD.gn.patch
+++ b/patches/tvos/BUILD.gn.patch
@@ -1,0 +1,39 @@
+diff --git a/sdk/BUILD.gn b/sdk/BUILD.gn
+index 79c1734..db4a5d5 100644
+--- a/sdk/BUILD.gn
++++ b/sdk/BUILD.gn
+@@ -681,14 +681,18 @@ if (is_ios || is_mac) {
+     rtc_library("videocapture_objc") {
+       visibility = [ "*" ]
+       allow_poison = [ "audio_codecs" ]  # TODO(bugs.webrtc.org/8396): Remove.
+       sources = [
+-        "objc/components/capturer/RTCCameraVideoCapturer.h",
+-        "objc/components/capturer/RTCCameraVideoCapturer.m",
+         "objc/components/capturer/RTCFileVideoCapturer.h",
+         "objc/components/capturer/RTCFileVideoCapturer.m",
+       ]
++      if (target_platform != "tvos") {
++        sources += [
++          "objc/components/capturer/RTCCameraVideoCapturer.h",
++          "objc/components/capturer/RTCCameraVideoCapturer.m",
++        ]
++      }
+       frameworks = [
+         "AVFoundation.framework",
+         "CoreVideo.framework",
+         "QuartzCore.framework",
+       ]
+@@ -1398,7 +1402,13 @@ if (is_ios || is_mac) {
+             "objc/api/logging/RTCCallbackLogger.h",
+             "objc/api/peerconnection/RTCFileLogger.h",
+           ]
+         }
++        if (target_platform == "tvos") {
++          common_objc_headers -= [
++            "objc/components/capturer/RTCCameraVideoCapturer.h",
++            "objc/helpers/RTCCameraPreviewView.h",
++          ]
++        }
+ 
+         sources = common_objc_headers
+         public_headers = common_objc_headers

--- a/patches/tvos/BUILD.gn.patch
+++ b/patches/tvos/BUILD.gn.patch
@@ -2,7 +2,7 @@ diff --git a/sdk/BUILD.gn b/sdk/BUILD.gn
 index 79c1734..db4a5d5 100644
 --- a/sdk/BUILD.gn
 +++ b/sdk/BUILD.gn
-@@ -681,14 +681,18 @@ if (is_ios || is_mac) {
+@@ -681,14 +681,25 @@ if (is_ios || is_mac) {
      rtc_library("videocapture_objc") {
        visibility = [ "*" ]
        allow_poison = [ "audio_codecs" ]  # TODO(bugs.webrtc.org/8396): Remove.
@@ -12,7 +12,14 @@ index 79c1734..db4a5d5 100644
          "objc/components/capturer/RTCFileVideoCapturer.h",
          "objc/components/capturer/RTCFileVideoCapturer.m",
        ]
-+      if (target_platform != "tvos") {
++      if (is_ios) {
++        if (target_platform != "tvos") {
++          sources += [
++            "objc/components/capturer/RTCCameraVideoCapturer.h",
++            "objc/components/capturer/RTCCameraVideoCapturer.m",
++          ]
++        }
++      } else {
 +        sources += [
 +          "objc/components/capturer/RTCCameraVideoCapturer.h",
 +          "objc/components/capturer/RTCCameraVideoCapturer.m",
@@ -23,16 +30,18 @@ index 79c1734..db4a5d5 100644
          "CoreVideo.framework",
          "QuartzCore.framework",
        ]
-@@ -1398,7 +1402,13 @@ if (is_ios || is_mac) {
+@@ -1398,7 +1409,15 @@ if (is_ios || is_mac) {
              "objc/api/logging/RTCCallbackLogger.h",
              "objc/api/peerconnection/RTCFileLogger.h",
            ]
          }
-+        if (target_platform == "tvos") {
-+          common_objc_headers -= [
-+            "objc/components/capturer/RTCCameraVideoCapturer.h",
-+            "objc/helpers/RTCCameraPreviewView.h",
-+          ]
++        if (is_ios) {
++          if (target_platform == "tvos") {
++            common_objc_headers -= [
++              "objc/components/capturer/RTCCameraVideoCapturer.h",
++              "objc/helpers/RTCCameraPreviewView.h",
++            ]
++          }
 +        }
  
          sources = common_objc_headers

--- a/patches/tvos/RTCAudioSessionConfiguration.patch
+++ b/patches/tvos/RTCAudioSessionConfiguration.patch
@@ -1,0 +1,15 @@
+diff --git a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+index 6c83f13..20349f2 100644
+--- a/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
++++ b/sdk/objc/components/audio/RTCAudioSessionConfiguration.m
+@@ -61,7 +61,9 @@ - (instancetype)init {
+     // nonmixable, hence activating the session will interrupt any other
+     // audio sessions which are also nonmixable.
+     _category = AVAudioSessionCategoryPlayAndRecord;
+-#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
++#if TARGET_OS_TV
++    _categoryOptions = 0;
++#elif defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+     _categoryOptions = AVAudioSessionCategoryOptionAllowBluetoothHFP;
+ #else
+     // Use the deprecated option on older SDKs.

--- a/patches/tvos/RTCMTLRenderer.patch
+++ b/patches/tvos/RTCMTLRenderer.patch
@@ -1,0 +1,13 @@
+diff --git a/sdk/objc/components/renderer/metal/RTCMTLRenderer.h b/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
+index 0eb6b3d..80574a6 100644
+--- a/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
++++ b/sdk/objc/components/renderer/metal/RTCMTLRenderer.h
+@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
+  * for performing cleanups.
+  */
+ 
+-#if TARGET_OS_IOS
++#if TARGET_OS_IPHONE
+ - (BOOL)addRenderingDestination:(__kindof UIView *)view;
+ #else
+ - (BOOL)addRenderingDestination:(__kindof NSView *)view;

--- a/patches/tvos/VoiceProcessingAudioUnit.patch
+++ b/patches/tvos/VoiceProcessingAudioUnit.patch
@@ -1,0 +1,13 @@
+diff --git a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+index 19534fb..fe0646e 100644
+--- a/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
++++ b/sdk/objc/native/src/audio/voice_processing_audio_unit.mm
+@@ -280,7 +280,7 @@ bool VoiceProcessingAudioUnit::Initialize(AudioDeviceBuffer* audio_device_buffer
+   }
+ 
+   if (detect_mute_speech_) {
+-    if (@available(iOS 15, *)) {
++    if (@available(iOS 15, tvOS 17, *)) {
+       // Set listener for muted speech event.
+       AUVoiceIOMutedSpeechActivityEventListener listener =
+           ^(AUVoiceIOSpeechActivityEvent event) {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,9 +62,10 @@ build_tvOS() {
 }
 
 apply_tvOS_patches() {
-    local patch_file="${ROOT_DIR}/patches/tvos/RTCAudioSessionConfiguration.patch"
-    git apply --check "${patch_file}" || exit 1
-    git apply "${patch_file}" || exit 1
+    for patch_file in "${ROOT_DIR}"/patches/tvos/*.patch; do
+        git apply --check "${patch_file}" || exit 1
+        git apply "${patch_file}" || exit 1
+    done
 }
 
 plist_add_library() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -134,7 +134,6 @@ if [ "$MAC_CATALYST" = true ]; then
 fi
 
 if [ "$TVOS" = true ]; then
-    build_tvOS "x64" "simulator"
     build_tvOS "arm64" "simulator"
     build_tvOS "arm64" "device"
 fi
@@ -220,7 +219,7 @@ fi
 if [ "$TVOS" = true ]; then
 
     TVOS_LIB_IDENTIFIER="tvos-arm64"
-    TVOS_SIM_LIB_IDENTIFIER="tvos-x86_64_arm64-simulator"
+    TVOS_SIM_LIB_IDENTIFIER="tvos-arm64-simulator"
 
     mkdir "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}"
     mkdir "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}"
@@ -230,14 +229,13 @@ if [ "$TVOS" = true ]; then
     plist_add_library $LIB_TVOS_SIMULATOR_INDEX $TVOS_SIM_LIB_IDENTIFIER "tvos" "simulator"
 
     cp -r "${OUTPUT_DIR}/tvos-arm64-device/WebRTC.framework" "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}"
-    cp -r "${OUTPUT_DIR}/tvos-x64-simulator/WebRTC.framework" "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}"
+    cp -r "${OUTPUT_DIR}/tvos-arm64-simulator/WebRTC.framework" "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}"
 
     LIPO_TVOS_FLAGS="${OUTPUT_DIR}/tvos-arm64-device/WebRTC.framework/WebRTC"
-    LIPO_TVOS_SIM_FLAGS="${OUTPUT_DIR}/tvos-x64-simulator/WebRTC.framework/WebRTC ${OUTPUT_DIR}/tvos-arm64-simulator/WebRTC.framework/WebRTC"
+    LIPO_TVOS_SIM_FLAGS="${OUTPUT_DIR}/tvos-arm64-simulator/WebRTC.framework/WebRTC"
 
     plist_add_architecture $LIB_TVOS_INDEX "arm64"
     plist_add_architecture $LIB_TVOS_SIMULATOR_INDEX "arm64"
-    plist_add_architecture $LIB_TVOS_SIMULATOR_INDEX "x86_64"
 
     lipo -create -output  "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_TVOS_FLAGS}
     lipo -create -output "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_TVOS_SIM_FLAGS}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,6 +61,12 @@ build_tvOS() {
     ninja -C "${gen_dir}" framework_objc || exit 1
 }
 
+apply_tvOS_patches() {
+    local patch_file="${ROOT_DIR}/patches/tvos/RTCAudioSessionConfiguration.patch"
+    git apply --check "${patch_file}" || exit 1
+    git apply "${patch_file}" || exit 1
+}
+
 plist_add_library() {
     local index=$1
     local identifier=$2
@@ -102,6 +108,10 @@ git checkout $BRANCH
 cd ..
 gclient sync --with_branch_heads --with_tags
 cd src
+
+if [ "$TVOS" = true ]; then
+    apply_tvOS_patches
+fi
 
 # Step 3 - Compile and build all frameworks
 rm -rf $OUTPUT_DIR  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,7 +4,7 @@
 ## Created by Stasel
 ## BSD-3 License
 ## 
-## Example usage (from the repository root): BRANCH=branch-heads/7727 MACOS=true IOS=true sh scripts/build.sh
+## Example usage (from the repository root): BRANCH=branch-heads/7727 MACOS=true IOS=true TVOS=true sh scripts/build.sh
 
 # Configs
 DEBUG="${DEBUG:-false}"
@@ -12,6 +12,7 @@ BRANCH="${BRANCH:-main}"
 IOS="${IOS:-false}"
 MACOS="${MACOS:-false}"
 MAC_CATALYST="${MAC_CATALYST:-false}"
+TVOS="${TVOS:-false}"
 
 ROOT_DIR="$(pwd)"
 OUTPUT_DIR="${ROOT_DIR}/out"
@@ -45,6 +46,16 @@ build_catalyst() {
     local arch=$1
     local gen_dir="${OUTPUT_DIR}/catalyst-${arch}"
     local gen_args="${COMMON_GN_ARGS} target_cpu=\"${arch}\" target_environment=\"catalyst\" target_os=\"ios\" ios_deployment_target=\"14.0\" ios_enable_code_signing=false"
+    gn gen "${gen_dir}" --args="${gen_args}"
+    gn args --list ${gen_dir} > ${gen_dir}/gn-args.txt
+    ninja -C "${gen_dir}" framework_objc || exit 1
+}
+
+build_tvOS() {
+    local arch=$1
+    local environment=$2
+    local gen_dir="${OUTPUT_DIR}/tvos-${arch}-${environment}"
+    local gen_args="${COMMON_GN_ARGS} target_cpu=\"${arch}\" target_os=\"ios\" target_platform=\"tvos\" target_environment=\"${environment}\" ios_deployment_target=\"12.0\" ios_enable_code_signing=false use_blink=true"
     gn gen "${gen_dir}" --args="${gen_args}"
     gn args --list ${gen_dir} > ${gen_dir}/gn-args.txt
     ninja -C "${gen_dir}" framework_objc || exit 1
@@ -109,6 +120,12 @@ fi
 if [ "$MAC_CATALYST" = true ]; then
     build_catalyst "x64"
     build_catalyst "arm64"
+fi
+
+if [ "$TVOS" = true ]; then
+    build_tvOS "x64" "simulator"
+    build_tvOS "arm64" "simulator"
+    build_tvOS "arm64" "device"
 fi
 
 # Step 4 - Manually create XCFramework.
@@ -188,6 +205,39 @@ if [ "$MAC_CATALYST" = true ]; then
     LIB_COUNT=$((LIB_COUNT+1))
 fi
 
+# Step 5.4 - Add tvOS libs to XCFramework
+if [ "$TVOS" = true ]; then
+
+    TVOS_LIB_IDENTIFIER="tvos-arm64"
+    TVOS_SIM_LIB_IDENTIFIER="tvos-x86_64_arm64-simulator"
+
+    mkdir "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}"
+    mkdir "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}"
+    LIB_TVOS_INDEX=$LIB_COUNT
+    LIB_TVOS_SIMULATOR_INDEX=$((LIB_COUNT+1))
+    plist_add_library $LIB_TVOS_INDEX $TVOS_LIB_IDENTIFIER "tvos"
+    plist_add_library $LIB_TVOS_SIMULATOR_INDEX $TVOS_SIM_LIB_IDENTIFIER "tvos" "simulator"
+
+    cp -r "${OUTPUT_DIR}/tvos-arm64-device/WebRTC.framework" "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}"
+    cp -r "${OUTPUT_DIR}/tvos-x64-simulator/WebRTC.framework" "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}"
+
+    LIPO_TVOS_FLAGS="${OUTPUT_DIR}/tvos-arm64-device/WebRTC.framework/WebRTC"
+    LIPO_TVOS_SIM_FLAGS="${OUTPUT_DIR}/tvos-x64-simulator/WebRTC.framework/WebRTC ${OUTPUT_DIR}/tvos-arm64-simulator/WebRTC.framework/WebRTC"
+
+    plist_add_architecture $LIB_TVOS_INDEX "arm64"
+    plist_add_architecture $LIB_TVOS_SIMULATOR_INDEX "arm64"
+    plist_add_architecture $LIB_TVOS_SIMULATOR_INDEX "x86_64"
+
+    lipo -create -output  "${XCFRAMEWORK_DIR}/${TVOS_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_TVOS_FLAGS}
+    lipo -create -output "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}/WebRTC.framework/WebRTC" ${LIPO_TVOS_SIM_FLAGS}
+
+    # codesign simulator framework for local development.
+    # This makes it possible for Swift Packages to run Unit Tests and show SwiftUI Previews.
+    xcrun codesign -s - "${XCFRAMEWORK_DIR}/${TVOS_SIM_LIB_IDENTIFIER}/WebRTC.framework/WebRTC"
+
+    LIB_COUNT=$((LIB_COUNT+2))
+fi
+
 # Step 6 - Add license file to the framework
 cp LICENSE ${XCFRAMEWORK_DIR}
 
@@ -203,4 +253,3 @@ COMMIT_HASH=$(git rev-parse HEAD)
 
 echo "{ \"file\": \"${OUTPUT_NAME}\", \"checksum\": \"${CHECKSUM}\", \"commit\": \"${COMMIT_HASH}\", \"branch\": \"${BRANCH}\" }" > metadata.json
 cat metadata.json
-

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,6 +70,7 @@ def buildWebRTC(branch):
     os.environ["IOS"] = "true"
     os.environ["MACOS"] = "true"
     os.environ["MAC_CATALYST"] = "true"
+    os.environ["TVOS"] = "true"
 
     return os.system('sh scripts/build.sh') == 0
 

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -33,5 +33,7 @@ assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'TARGET_OS_TV' "
 assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'AVAudioSessionCategoryOptionAllowBluetooth' "tvOS Bluetooth option patch context"
 assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'tvOS 17' "tvOS muted speech listener availability guard"
 assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'AUVoiceIOMutedSpeechActivityEventListener' "tvOS muted speech listener patch context"
+assert_contains patches/tvos/RTCMTLRenderer.patch 'TARGET_OS_IPHONE' "tvOS Metal renderer UIKit gate"
+assert_contains patches/tvos/RTCMTLRenderer.patch 'addRenderingDestination' "tvOS Metal renderer patch context"
 
 echo "tvOS support metadata is present"

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -13,6 +13,17 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    file=$1
+    pattern=$2
+    description=$3
+
+    if rg -q "$pattern" "$file"; then
+        echo "Unexpected ${description} in ${file}" >&2
+        exit 1
+    fi
+}
+
 assert_contains scripts/build.sh 'TVOS="\$\{TVOS:-false\}"' "TVOS build toggle"
 assert_contains scripts/build.sh 'build_tvOS\(\)' "tvOS build function"
 assert_contains scripts/build.sh 'apply_tvOS_patches\(\)' "tvOS source patch function"
@@ -20,7 +31,9 @@ assert_contains scripts/build.sh 'patches/tvos/\*.patch' "tvOS source patch glob
 assert_contains scripts/build.sh 'target_platform=\\"tvos\\"' "tvOS GN target platform"
 assert_contains scripts/build.sh 'use_blink=true' "tvOS GN use_blink override"
 assert_contains scripts/build.sh 'TVOS_LIB_IDENTIFIER="tvos-arm64"' "tvOS device XCFramework library"
-assert_contains scripts/build.sh 'TVOS_SIM_LIB_IDENTIFIER="tvos-x86_64_arm64-simulator"' "tvOS simulator XCFramework library"
+assert_contains scripts/build.sh 'TVOS_SIM_LIB_IDENTIFIER="tvos-arm64-simulator"' "tvOS simulator XCFramework library"
+assert_not_contains scripts/build.sh 'build_tvOS "x64" "simulator"' "x86_64 tvOS simulator build"
+assert_not_contains scripts/build.sh 'tvos-x64-simulator' "x86_64 tvOS simulator packaging"
 assert_contains .github/workflows/webrtc-build.yml 'tvos:' "manual workflow tvOS input"
 assert_contains .github/workflows/webrtc-build.yml 'TVOS: \$\{\{ inputs.tvos \}\}' "manual workflow TVOS env"
 assert_contains scripts/release.py 'os.environ\["TVOS"\] = "true"' "release TVOS env"

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -15,6 +15,8 @@ assert_contains() {
 
 assert_contains scripts/build.sh 'TVOS="\$\{TVOS:-false\}"' "TVOS build toggle"
 assert_contains scripts/build.sh 'build_tvOS\(\)' "tvOS build function"
+assert_contains scripts/build.sh 'apply_tvOS_patches\(\)' "tvOS source patch function"
+assert_contains scripts/build.sh 'patches/tvos/RTCAudioSessionConfiguration.patch' "tvOS audio session source patch hook"
 assert_contains scripts/build.sh 'target_platform=\\"tvos\\"' "tvOS GN target platform"
 assert_contains scripts/build.sh 'use_blink=true' "tvOS GN use_blink override"
 assert_contains scripts/build.sh 'TVOS_LIB_IDENTIFIER="tvos-arm64"' "tvOS device XCFramework library"
@@ -27,5 +29,7 @@ assert_contains WebRTC-lib.podspec "spec.tvos.deployment_target = '12.0'" "Cocoa
 assert_contains README.md 'tvOS 12\+' "README tvOS requirement"
 assert_contains README.md '\*\*tvOS \(device\)\*\*' "README tvOS device binary row"
 assert_contains README.md '\*\*tvOS \(simulator\)\*\*' "README tvOS simulator binary row"
+assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'TARGET_OS_TV' "tvOS audio session availability guard"
+assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'AVAudioSessionCategoryOptionAllowBluetooth' "tvOS Bluetooth option patch context"
 
 echo "tvOS support metadata is present"

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+assert_contains() {
+    file=$1
+    pattern=$2
+    description=$3
+
+    if ! rg -q "$pattern" "$file"; then
+        echo "Missing ${description} in ${file}" >&2
+        exit 1
+    fi
+}
+
+assert_contains scripts/build.sh 'TVOS="\$\{TVOS:-false\}"' "TVOS build toggle"
+assert_contains scripts/build.sh 'build_tvOS\(\)' "tvOS build function"
+assert_contains scripts/build.sh 'target_platform=\\"tvos\\"' "tvOS GN target platform"
+assert_contains scripts/build.sh 'use_blink=true' "tvOS GN use_blink override"
+assert_contains scripts/build.sh 'TVOS_LIB_IDENTIFIER="tvos-arm64"' "tvOS device XCFramework library"
+assert_contains scripts/build.sh 'TVOS_SIM_LIB_IDENTIFIER="tvos-x86_64_arm64-simulator"' "tvOS simulator XCFramework library"
+assert_contains .github/workflows/webrtc-build.yml 'tvos:' "manual workflow tvOS input"
+assert_contains .github/workflows/webrtc-build.yml 'TVOS: \$\{\{ inputs.tvos \}\}' "manual workflow TVOS env"
+assert_contains scripts/release.py 'os.environ\["TVOS"\] = "true"' "release TVOS env"
+assert_contains Package.swift '\.tvOS\(\.v12\)' "SwiftPM tvOS platform"
+assert_contains WebRTC-lib.podspec "spec.tvos.deployment_target = '12.0'" "CocoaPods tvOS deployment target"
+assert_contains README.md 'tvOS 12\+' "README tvOS requirement"
+assert_contains README.md '\*\*tvOS \(device\)\*\*' "README tvOS device binary row"
+assert_contains README.md '\*\*tvOS \(simulator\)\*\*' "README tvOS simulator binary row"
+
+echo "tvOS support metadata is present"

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -16,7 +16,7 @@ assert_contains() {
 assert_contains scripts/build.sh 'TVOS="\$\{TVOS:-false\}"' "TVOS build toggle"
 assert_contains scripts/build.sh 'build_tvOS\(\)' "tvOS build function"
 assert_contains scripts/build.sh 'apply_tvOS_patches\(\)' "tvOS source patch function"
-assert_contains scripts/build.sh 'patches/tvos/RTCAudioSessionConfiguration.patch' "tvOS audio session source patch hook"
+assert_contains scripts/build.sh 'patches/tvos/\*.patch' "tvOS source patch glob"
 assert_contains scripts/build.sh 'target_platform=\\"tvos\\"' "tvOS GN target platform"
 assert_contains scripts/build.sh 'use_blink=true' "tvOS GN use_blink override"
 assert_contains scripts/build.sh 'TVOS_LIB_IDENTIFIER="tvos-arm64"' "tvOS device XCFramework library"
@@ -31,5 +31,7 @@ assert_contains README.md '\*\*tvOS \(device\)\*\*' "README tvOS device binary r
 assert_contains README.md '\*\*tvOS \(simulator\)\*\*' "README tvOS simulator binary row"
 assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'TARGET_OS_TV' "tvOS audio session availability guard"
 assert_contains patches/tvos/RTCAudioSessionConfiguration.patch 'AVAudioSessionCategoryOptionAllowBluetooth' "tvOS Bluetooth option patch context"
+assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'tvOS 17' "tvOS muted speech listener availability guard"
+assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'AUVoiceIOMutedSpeechActivityEventListener' "tvOS muted speech listener patch context"
 
 echo "tvOS support metadata is present"

--- a/scripts/test_tvos_support.sh
+++ b/scripts/test_tvos_support.sh
@@ -35,5 +35,7 @@ assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'tvOS 17' "tvOS mute
 assert_contains patches/tvos/VoiceProcessingAudioUnit.patch 'AUVoiceIOMutedSpeechActivityEventListener' "tvOS muted speech listener patch context"
 assert_contains patches/tvos/RTCMTLRenderer.patch 'TARGET_OS_IPHONE' "tvOS Metal renderer UIKit gate"
 assert_contains patches/tvos/RTCMTLRenderer.patch 'addRenderingDestination' "tvOS Metal renderer patch context"
+assert_contains patches/tvos/BUILD.gn.patch 'target_platform != "tvos"' "tvOS camera capturer build exclusion"
+assert_contains patches/tvos/BUILD.gn.patch 'RTCCameraVideoCapturer.h' "tvOS camera capturer header exclusion"
 
 echo "tvOS support metadata is present"


### PR DESCRIPTION
## Summary

Adds tvOS support to the WebRTC binary distribution so `WebRTC.xcframework` can be consumed by tvOS apps through CocoaPods / Swift Package Manager.

This includes:

- tvOS device build slice
- tvOS simulator build slice
- tvOS entries in the generated `WebRTC.xcframework`
- tvOS platform metadata in `Package.swift`
- tvOS deployment target in `WebRTC-lib.podspec`
- GitHub Actions support for building tvOS artifacts

The change is based on the existing iOS/macOS/Catalyst build flow and keeps existing supported platforms unchanged.

## Motivation

`WebRTC-lib` currently works for iOS/macOS/Catalyst, but tvOS apps cannot import/link the framework because the released XCFramework does not include tvOS slices.